### PR TITLE
ISLANDORA-1529: Allow anonymous owner to not be "Everyone" in overview page

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -24,6 +24,12 @@ function islandora_bookmark_admin_settings(array $form, array &$form_state) {
       '#description' => t('The unpluralized name of the type of lists such as bookmark or favorite.'),
       '#default_value' => variable_get('islandora_bookmark_type', 'bookmark'),
     ),
+    'anonymous_owner' => array(
+      '#type' => 'textfield',
+      '#title' => t('The owner name to display for anonymous users.'),
+      '#description' => t('The name to display in the owner column for users who are not logged in.'),
+      '#default_value' => variable_get('islandora_bookmark_owner', 'Me'),
+    ),
     'overview_page_elements' => array(
       '#type' => 'textfield',
       '#title' => t('Bookmarks overview table'),
@@ -120,6 +126,7 @@ function islandora_bookmark_admin_settings_submit(array $form, array &$form_stat
       variable_set('islandora_bookmark_overview_page_elements', $form_state['values']['overview_page_elements']);
       variable_set('islandora_bookmark_detailed_page_elements', $form_state['values']['detailed_page_elements']);
       variable_set('islandora_bookmark_type', $form_state['values']['list_type']);
+      variable_set('islandora_bookmark_owner', $form_state['values']['anonymous_owner']);
       variable_set('islandora_bookmark_create_user_default_lists', $form_state['values']['create_user_default_lists']);
       if ($form_state['values']['create_user_default_lists']) {
         variable_set('islandora_bookmark_default_list_name', $form_state['values']['default_list_name']);
@@ -132,6 +139,7 @@ function islandora_bookmark_admin_settings_submit(array $form, array &$form_stat
       variable_del('islandora_bookmark_overview_page_elements');
       variable_del('islandora_bookmark_detailed_page_elements');
       variable_del('islandora_bookmark_type');
+      variable_del('islandora_bookmark_owner');
       variable_del('islandora_bookmark_create_user_default_lists');
       variable_del('islandora_bookmark_default_list_name');
       variable_del('islandora_bookmark_share_default_list');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -28,7 +28,7 @@ function islandora_bookmark_admin_settings(array $form, array &$form_state) {
       '#type' => 'textfield',
       '#title' => t('The owner name to display for anonymous users.'),
       '#description' => t('The name to display in the owner column for users who are not logged in.'),
-      '#default_value' => variable_get('islandora_bookmark_owner', 'Me'),
+      '#default_value' => variable_get('islandora_bookmark_owner', 'Everyone'),
     ),
     'overview_page_elements' => array(
       '#type' => 'textfield',

--- a/includes/bookmark.inc
+++ b/includes/bookmark.inc
@@ -626,7 +626,7 @@ abstract class Bookmark implements BookmarkInterface {
             $add_user = $form_state['input']['bookmarks']['users']['listusers'];
             if (drupal_strlen($add_user)) {
               if ($add_user == 0) {
-                $output_user = t('Everyone');
+                $output_user = variable_get('islandora_bookmark_owner', 'Me');
               }
               else {
                 $output_user = user_load($add_user)->name;
@@ -643,7 +643,7 @@ abstract class Bookmark implements BookmarkInterface {
             $row = $form_state['triggering_element']['#row'];
             $remove_user = $form_state['values']['bookmarks']['users'][$row]['user'];
             if ($remove_user == 0) {
-              $output_user = t('Everyone');
+              $output_user = variable_get('islandora_bookmark_owner', 'Me');
             }
             else {
               $output_user = user_load($remove_user)->name;
@@ -683,7 +683,7 @@ abstract class Bookmark implements BookmarkInterface {
             foreach ($bookmark_users as $itr => $uid) {
               $tempuser = user_load($uid);
               if ($tempuser->uid == 0) {
-                $user_output = t('Everyone');
+                $user_output = variable_get('islandora_bookmark_owner', 'Me');
               }
               else {
                 $user_output = $tempuser->name;
@@ -728,7 +728,7 @@ abstract class Bookmark implements BookmarkInterface {
           if ($user->uid != 0) {
             $options['0'] = array(
               'uid' => 0,
-              'name' => t('Everyone'),
+              'name' => variable_get('islandora_bookmark_owner', 'Me'),
             );
           }
           // Get all users for use in select for forms.
@@ -741,7 +741,7 @@ abstract class Bookmark implements BookmarkInterface {
 
           $options += $result->fetchAllAssoc('uid', PDO::FETCH_ASSOC);
           if (isset($options['0'])) {
-            $options[0]['name'] = t('Everyone');
+            $options[0]['name'] = variable_get('islandora_bookmark_owner', 'Me');
           }
 
           $available = array_diff_key($options, drupal_map_assoc($this->getUsers()));

--- a/includes/bookmark.inc
+++ b/includes/bookmark.inc
@@ -626,7 +626,7 @@ abstract class Bookmark implements BookmarkInterface {
             $add_user = $form_state['input']['bookmarks']['users']['listusers'];
             if (drupal_strlen($add_user)) {
               if ($add_user == 0) {
-                $output_user = variable_get('islandora_bookmark_owner', 'Me');
+                $output_user = variable_get('islandora_bookmark_owner', 'Everyone');
               }
               else {
                 $output_user = user_load($add_user)->name;
@@ -643,7 +643,7 @@ abstract class Bookmark implements BookmarkInterface {
             $row = $form_state['triggering_element']['#row'];
             $remove_user = $form_state['values']['bookmarks']['users'][$row]['user'];
             if ($remove_user == 0) {
-              $output_user = variable_get('islandora_bookmark_owner', 'Me');
+              $output_user = variable_get('islandora_bookmark_owner', 'Everyone');
             }
             else {
               $output_user = user_load($remove_user)->name;
@@ -683,7 +683,7 @@ abstract class Bookmark implements BookmarkInterface {
             foreach ($bookmark_users as $itr => $uid) {
               $tempuser = user_load($uid);
               if ($tempuser->uid == 0) {
-                $user_output = variable_get('islandora_bookmark_owner', 'Me');
+                $user_output = variable_get('islandora_bookmark_owner', 'Everyone');
               }
               else {
                 $user_output = $tempuser->name;
@@ -728,7 +728,7 @@ abstract class Bookmark implements BookmarkInterface {
           if ($user->uid != 0) {
             $options['0'] = array(
               'uid' => 0,
-              'name' => variable_get('islandora_bookmark_owner', 'Me'),
+              'name' => variable_get('islandora_bookmark_owner', 'Everyone'),
             );
           }
           // Get all users for use in select for forms.
@@ -741,7 +741,7 @@ abstract class Bookmark implements BookmarkInterface {
 
           $options += $result->fetchAllAssoc('uid', PDO::FETCH_ASSOC);
           if (isset($options['0'])) {
-            $options[0]['name'] = variable_get('islandora_bookmark_owner', 'Me');
+            $options[0]['name'] = variable_get('islandora_bookmark_owner', 'Everyone');
           }
 
           $available = array_diff_key($options, drupal_map_assoc($this->getUsers()));

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -991,7 +991,7 @@ function islandora_bookmark_form_overview_table(array $bookmark_objs) {
   foreach ($bookmark_objs as $bookmark) {
     $owner = user_load($bookmark->bookmarkOwner);
     if ($bookmark->bookmarkOwner == 0) {
-      $owner_output = variable_get('islandora_bookmark_owner', 'Me');
+      $owner_output = variable_get('islandora_bookmark_owner', 'Everyone');
 ;
     }
     else {

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -317,7 +317,7 @@ function islandora_bookmark_user_login(&$edit, $account) {
           $default_list_name = format_string($default_list_name, array('@username' => $account->name));
           $persistent_bookmark = BookmarkDefaultDatabaseList::createNewList($default_list_name, 'bookmark_default', $account);
           if (variable_get('islandora_bookmark_share_default_list', FALSE)) {
-            // The anonymous user (uid 0) is considered to be "Everyone".
+            // The anonymous user (uid 0) is set in the admin form.
             $persistent_bookmark->addUser('0');
           }
         }
@@ -339,7 +339,7 @@ function islandora_bookmark_user_login(&$edit, $account) {
       $default_list_name = format_string($default_list_name, array('@username' => $account->name));
       $created_default_list = BookmarkDefaultDatabaseList::createNewList($default_list_name, 'bookmark_default', $account);
       if (variable_get('islandora_bookmark_share_default_list', FALSE)) {
-        // The anonymous user (uid 0) is considered to be "Everyone".
+        // The anonymous user (uid 0) is set in the admin form.
         $created_default_list->addUser('0');
       }
     }

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -991,7 +991,8 @@ function islandora_bookmark_form_overview_table(array $bookmark_objs) {
   foreach ($bookmark_objs as $bookmark) {
     $owner = user_load($bookmark->bookmarkOwner);
     if ($bookmark->bookmarkOwner == 0) {
-      $owner_output = t('Everyone');
+      $owner_output = variable_get('islandora_bookmark_owner', 'Me');
+;
     }
     else {
       $owner_output = $owner->name;

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -992,7 +992,6 @@ function islandora_bookmark_form_overview_table(array $bookmark_objs) {
     $owner = user_load($bookmark->bookmarkOwner);
     if ($bookmark->bookmarkOwner == 0) {
       $owner_output = variable_get('islandora_bookmark_owner', 'Everyone');
-;
     }
     else {
       $owner_output = $owner->name;


### PR DESCRIPTION
Added ability to change anonymous owner to not say "Everyone" on lists overview page. In the admin form you can now specify what you want listed as the owner when the list is not assigned to a Drupal user.
