### PR TITLE
Move to db_select for optional type.

### DIFF
--- a/includes/api.inc
+++ b/includes/api.inc
@@ -10,8 +10,8 @@
  *
  * @global stdClass $user
  *
- * @param string $type
- *   The type of bookmark to search for.
+ * @param string|NULL $type
+ *   Optional type of bookmark to retrieve. Defaults to all bookmarks.
  *
  * @return array
  *   An array of PidList objects.

--- a/includes/api.inc
+++ b/includes/api.inc
@@ -10,14 +10,24 @@
  *
  * @global stdClass $user
  *
+ * @param string $type
+ *   The type of bookmark to search for.
+ *
  * @return array
  *   An array of PidList objects.
  */
-function islandora_bookmark_get_user_owned_bookmarks() {
+function islandora_bookmark_get_user_owned_bookmarks($type = NULL) {
   global $user;
-
-  $list_query = db_query('SELECT DISTINCT listid FROM {islandora_bookmark_list_names} WHERE listowner = :uid ORDER BY listid', array(':uid' => $user->uid));
-  $listids = (array) $list_query->fetchAll(PDO::FETCH_COLUMN);
+  $list_query = db_select('islandora_bookmark_list_names', 'i')
+    ->fields('i', array('listid'))
+    ->condition('listowner', $user->uid)
+    ->orderBy('listid')
+    ->distinct();
+  if ($type) {
+    $list_query = $list_query->condition('type', $type);
+  }
+  $listids = (array) $list_query->execute()
+    ->fetchAll(PDO::FETCH_COLUMN);
 
   $bookmark_list = array();
   foreach ($listids as $list_id) {


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1622 
# What does this Pull Request do?

Replaces `db_query` with `db_select` which allows for querying for only certain types of Bookmarks.
# How should this be tested?

 The "My bookmarks" menu path (islandora-bookmark) still shows all bookmark lists sorted by listids.
# Background context:

As Bookmark implements a class based architecture arbitrary custom types can be created. It's possible that we may only want to retrieve certain types of Bookmarks. 
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @Islandora/7-x-1-x-committers as I'm the maintainer. 
## Thanks!

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
