### PR TITLE
ISLANDORA-1651: Caching respectful anonymous SESSION handling 

### DIFF
--- a/includes/api.inc
+++ b/includes/api.inc
@@ -39,7 +39,7 @@ function islandora_bookmark_get_user_owned_bookmarks($type = NULL) {
   // User is anon, use session as well.
   if ($user->uid == 0) {
     if (!isset($_SESSION) || empty($_SESSION['islandora_bookmark']) && variable_get('islandora_bookmark_create_user_default_lists', FALSE)) {
-      BookmarkDefaultSessionList::createNewList(t('My Default List'), 'bookmark_default', $user);
+      $bookmark_list[] = BookmarkDefaultSessionList::createNewList(t('My Default List'), $user, 'Default bookmark');
     }
 
     if (!empty($_SESSION['islandora_bookmark'])) {
@@ -119,7 +119,7 @@ function islandora_bookmark_get_bookmarks_visible_to_user($pid, $uid) {
   // SESSION FIRST.
   if ($uid == 0) {
     if (!isset($_SESSION) || empty($_SESSION['islandora_bookmark']) && variable_get('islandora_bookmark_create_user_default_lists', FALSE)) {
-      BookmarkDefaultSessionList::createNewList(t('My Default List'), 'bookmark_default', NULL);
+      BookmarkDefaultSessionList::createNewList(t('My Default List'), NULL, 'Default bookmark');
     }
     if (isset($_SESSION['islandora_bookmark'])) {
       foreach ($_SESSION['islandora_bookmark'] as $value) {

--- a/includes/api.inc
+++ b/includes/api.inc
@@ -38,13 +38,19 @@ function islandora_bookmark_get_user_owned_bookmarks($type = NULL) {
 
   // User is anon, use session as well.
   if ($user->uid == 0) {
-    if (!isset($_SESSION) || empty($_SESSION['islandora_bookmark']) && variable_get('islandora_bookmark_create_user_default_lists', FALSE)) {
+    if (!isset($_SESSION) || !isset($_SESSION['islandora_bookmark']) || empty($_SESSION['islandora_bookmark']) && variable_get('islandora_bookmark_create_user_default_lists', FALSE)) {
       $bookmark_list[] = BookmarkDefaultSessionList::createNewList(t('My Default List'), $user, 'Default bookmark');
     }
 
     if (!empty($_SESSION['islandora_bookmark'])) {
       foreach (array_keys($_SESSION['islandora_bookmark']) as $id) {
         $bookmark_list[] = BookmarkSession::getList($id);
+      }
+      if (count($_SESSION['islandora_bookmark']) == 1) {
+         $list = reset($_SESSION['islandora_bookmark']);
+         if ($list->getPidCount() == 0) {
+           unset($_SESSION['islandora_bookmark']);
+         }
       }
     }
   }
@@ -116,12 +122,8 @@ function islandora_bookmark_get_bookmark_by_number($listid) {
  */
 function islandora_bookmark_get_bookmarks_visible_to_user($pid, $uid) {
   $lists = array();
-  // SESSION FIRST.
   if ($uid == 0) {
-    if (!isset($_SESSION) || empty($_SESSION['islandora_bookmark']) && variable_get('islandora_bookmark_create_user_default_lists', FALSE)) {
-      BookmarkDefaultSessionList::createNewList(t('My Default List'), NULL, 'Default bookmark');
-    }
-    if (isset($_SESSION['islandora_bookmark'])) {
+   if (isset($_SESSION['islandora_bookmark'])) {
       foreach ($_SESSION['islandora_bookmark'] as $value) {
         $templist = $value;
         if (in_array($pid, $templist->getPids())) {

--- a/includes/api.inc
+++ b/includes/api.inc
@@ -2,16 +2,16 @@
 
 /**
  * @file
- * Houses helper functions used in the islandora_bookmark module
+ * Houses helper functions used in the islandora_bookmark module.
  */
 
 /**
  * Retrieves lists that the specified user has access to.
  *
- * @global stdClass $user
- *
- * @param string|NULL $type
+ * @param string|null $type
  *   Optional type of bookmark to retrieve. Defaults to all bookmarks.
+ *
+ * @global stdClass $user
  *
  * @return array
  *   An array of PidList objects.
@@ -47,10 +47,10 @@ function islandora_bookmark_get_user_owned_bookmarks($type = NULL) {
         $bookmark_list[] = BookmarkSession::getList($id);
       }
       if (count($_SESSION['islandora_bookmark']) == 1) {
-         $list = reset($_SESSION['islandora_bookmark']);
-         if ($list->getPidCount() == 0) {
-           unset($_SESSION['islandora_bookmark']);
-         }
+        $list = reset($_SESSION['islandora_bookmark']);
+        if ($list->getPidCount() == 0) {
+          unset($_SESSION['islandora_bookmark']);
+        }
       }
     }
   }
@@ -61,6 +61,7 @@ function islandora_bookmark_get_user_owned_bookmarks($type = NULL) {
  * Retrieves all Bookmarks the current user is shared on.
  *
  * @global stdClass $user
+ *
  * @return array
  *   An array of Bookmarks.
  */
@@ -93,10 +94,10 @@ function islandora_bookmark_get_user_shared_bookmarks() {
 /**
  * Retrieves a Bookmark given a specified ID.
  *
- * @global stdClass $user
- *
  * @param int $listid
  *   List ID to be searched for.
+ *
+ * @global stdClass $user
  *
  * @return bool|Bookmark
  *   PidList object or FALSE if the list does not exist.
@@ -123,7 +124,7 @@ function islandora_bookmark_get_bookmark_by_number($listid) {
 function islandora_bookmark_get_bookmarks_visible_to_user($pid, $uid) {
   $lists = array();
   if ($uid == 0) {
-   if (isset($_SESSION['islandora_bookmark'])) {
+    if (isset($_SESSION['islandora_bookmark'])) {
       foreach ($_SESSION['islandora_bookmark'] as $value) {
         $templist = $value;
         if (in_array($pid, $templist->getPids())) {

--- a/includes/bookmark.inc
+++ b/includes/bookmark.inc
@@ -419,6 +419,8 @@ abstract class Bookmark implements BookmarkInterface {
         );
         drupal_add_html_head($citation_export_head, 'citation_exporter_head');
       }
+      //Needed here, citation adds an empty _SESSION key by default
+      unset($_SESSION[CITATION_EXPORTER_INDEX_SESSION]);
     }
 
     $form = array(

--- a/includes/bookmark.inc
+++ b/includes/bookmark.inc
@@ -23,7 +23,6 @@ interface BookmarkInterface {
    *
    * @param int $offset
    *   The starting offset of pids to retrieve.
-   *
    * @param int $limit
    *   The number of pids to retrieve.
    *
@@ -71,11 +70,14 @@ interface BookmarkInterface {
    * should fail.
    */
   public function delete();
+
 }
 
 /**
- * Class that defines a Bookmark object. A Bookmark object needs only to be
- * constructed such that it contains a listname and listid for uniqueness.
+ * Class that defines a Bookmark object.
+ *
+ * A Bookmark object needs only to be constructed such that it
+ * contains a listname and listid for uniqueness.
  */
 abstract class Bookmark implements BookmarkInterface {
 
@@ -170,7 +172,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param bool $force_session_attempt
    *   Force examination of the session, to handle the hook_user_login() stuff.
    *
-   * @return Bookmark|NULL
+   * @return Bookmark|null
    *   Returns either an instantiated Bookmark object if the list exists, or
    *   NULL if we could not get it.
    */
@@ -211,7 +213,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param array $pids
    *   An array of pids.
    */
-  public function removePids($pids) {
+  public function removePids(array $pids) {
     foreach ($pids as $pid) {
       $this->removePid($pid);
     }
@@ -236,7 +238,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param array $users
    *   An array of integers, each representing a user ID.
    */
-  public function removeUsers($users) {
+  public function removeUsers(array $users) {
     foreach ($users as $user) {
       $this->removeUser($user);
     }
@@ -251,7 +253,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param array $pids
    *   An array of strings, representing object PIDs.
    */
-  public function addPids($pids) {
+  public function addPids(array $pids) {
     foreach ($pids as $pid) {
       $this->addPid($pid);
     }
@@ -266,7 +268,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param array $users
    *   An array of integers, representings user IDs.
    */
-  public function addUsers($users) {
+  public function addUsers(array $users) {
     foreach ($users as $user) {
       $this->addUser($user);
     }
@@ -348,7 +350,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @return array
    *   An associative array defining a tableselect element.
    */
-  protected function getTable($pids) {
+  protected function getTable(array $pids) {
     return array(
       '#type' => 'tableselect',
       '#header' => $this->getTableHeader(),
@@ -419,7 +421,7 @@ abstract class Bookmark implements BookmarkInterface {
         );
         drupal_add_html_head($citation_export_head, 'citation_exporter_head');
       }
-      //Needed here, citation adds an empty _SESSION key by default
+      // Needed here, citation adds an empty _SESSION key by default.
       unset($_SESSION[CITATION_EXPORTER_INDEX_SESSION]);
     }
 
@@ -463,8 +465,8 @@ abstract class Bookmark implements BookmarkInterface {
     $form['bookmarks']['fieldset'] += array(
       'table' => $table += array(
         '#empty' => t('@type list is empty.', array(
-      '@type' => ucwords(variable_get('islandora_bookmark_type', 'bookmark')),
-    )),
+          '@type' => ucwords(variable_get('islandora_bookmark_type', 'bookmark')),
+        )),
         '#weight' => -2,
       ),
       'pager' => array(
@@ -493,7 +495,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @param array $form_state
    *   The Drupal form state.
    */
-  protected function formAddActions(&$container, &$form_state) {
+  protected function formAddActions(array &$container, array &$form_state) {
     $groups = array();
 
     if ($this->managementAccess()) {
@@ -653,8 +655,7 @@ abstract class Bookmark implements BookmarkInterface {
             drupal_set_message(t('The user @username has been removed from the list @listname.', array(
               '@listname' => $this->bookmarkName,
               '@username' => $output_user,
-                    )
-            ));
+            )));
             $this->removeUsers(array($remove_user));
           }
         }
@@ -673,7 +674,9 @@ abstract class Bookmark implements BookmarkInterface {
           }
           else {
             $fku['title'] = array(
-              '#markup' => '<h3>' . t('Shared with') . ':</h3>',
+              '#prefix' => '<h3>',
+              '#suffix' => '</h3>',
+              '#markup' => t('Shared with:'),
             );
             // Remove the user from the populated shared users.
             $bookmark_users = $this->getUsers();
@@ -735,11 +738,11 @@ abstract class Bookmark implements BookmarkInterface {
           }
           // Get all users for use in select for forms.
           $result = db_select('users', 'u')
-              ->fields('u', array('uid', 'name'))
-              ->condition('STATUS', 0, '!=')
-              ->condition('uid', $user->uid, '!=')
-              ->orderBy('uid')
-              ->execute();
+            ->fields('u', array('uid', 'name'))
+            ->condition('STATUS', 0, '!=')
+            ->condition('uid', $user->uid, '!=')
+            ->orderBy('uid')
+            ->execute();
 
           $options += $result->fetchAllAssoc('uid', PDO::FETCH_ASSOC);
           if (isset($options['0'])) {
@@ -905,7 +908,7 @@ abstract class Bookmark implements BookmarkInterface {
    * @return array
    *   An array of PIDs--may be empty if there are none present.
    */
-  protected function formGetPidToRemove($form_state) {
+  protected function formGetPidToRemove(array $form_state) {
     $to_remove = preg_grep('/remove_pid_.*/', array_keys($form_state['input']));
     return preg_replace('/remove_pid_(.*)/', '$1', $to_remove);
   }
@@ -962,7 +965,7 @@ abstract class Bookmark implements BookmarkInterface {
     if (!empty($broken)) {
       watchdog('islandora_bookmark', 'Broken PIDs encountered: @pids', array(
         '@pids' => implode(', ', $broken),
-          ), WATCHDOG_WARNING);
+      ), WATCHDOG_WARNING);
     }
 
     return $functional;
@@ -978,7 +981,7 @@ abstract class Bookmark implements BookmarkInterface {
     if (!empty($broken)) {
       watchdog('islandora_bookmark', 'Broken PIDs encountered: @pids', array(
         '@pids' => implode(', ', $broken),
-          ), WATCHDOG_WARNING);
+      ), WATCHDOG_WARNING);
     }
 
     return $functional;

--- a/includes/bookmark_default_session.inc
+++ b/includes/bookmark_default_session.inc
@@ -6,11 +6,13 @@
  */
 
 /**
- * Class that defines a BookmarkDefaultSessionList object. A
- * BookmarkDefaultSessionList object only difference is that it cannot be
+ * Class that defines a BookmarkDefaultSessionList object.
+ *
+ * A BookmarkDefaultSessionList object only difference is that it cannot be
  * deleted.
  */
 class BookmarkDefaultSessionList extends BookmarkSession {
+
   /**
    * Constructor for the BookmarkDefaultSessionList object.
    */
@@ -25,12 +27,16 @@ class BookmarkDefaultSessionList extends BookmarkSession {
   public function delete() {
 
   }
-  
+
+  /**
+   * Adds PID to a Bookmark.
+   */
   public function addPid($pid) {
-    //Only set the $_SESSION keys when first $pid is added
+    // Only set the $_SESSION keys when first $pid is added.
     if (!isset($_SESSION['islandora_bookmark'][$this->bookmarkId])) {
       $_SESSION['islandora_bookmark'][$this->bookmarkId] = $this;
     }
     $this->pidList[] = $pid;
   }
+
 }

--- a/includes/bookmark_default_session.inc
+++ b/includes/bookmark_default_session.inc
@@ -12,7 +12,7 @@
  */
 class BookmarkDefaultSessionList extends BookmarkSession {
   /**
-   * Constructor for the BookmarkDefaultDatabaseList object.
+   * Constructor for the BookmarkDefaultSessionList object.
    */
   public function __construct($list_id) {
     parent::__construct($list_id);
@@ -24,5 +24,13 @@ class BookmarkDefaultSessionList extends BookmarkSession {
    */
   public function delete() {
 
+  }
+  
+  public function addPid($pid) {
+    //Only set the $_SESSION keys when first $pid is added
+    if (!isset($_SESSION['islandora_bookmark'][$this->bookmarkId])) {
+      $_SESSION['islandora_bookmark'][$this->bookmarkId] = $this;
+    }
+    $this->pidList[] = $pid;
   }
 }

--- a/includes/bookmark_session.inc
+++ b/includes/bookmark_session.inc
@@ -75,21 +75,28 @@ class BookmarkSession extends Bookmark {
    *   grab the global "$user" variable.
    * @param string $desc
    *   An optional description of the bookmark list.
+   * @param boolean $force
+   *   Force a list to be stored on session
    *
    * @return BookmarkDatabase
    *   A new Bookmark object.
    */
-  public static function createNewList($name, $owner = NULL, $desc = '') {
+  public static function createNewList($name, $owner = NULL, $desc = '', $force = FALSE) {
     if ($owner === NULL) {
       global $user;
       $owner = $user;
     }
-
     $list_id = static::getKey($name);
-
-    $_SESSION['islandora_bookmark'][$list_id] = new static($name, $desc);
-
-    return static::getList($list_id);
+    $newlist = new static($name, $desc);
+    if (!$newlist->getIsDeletable() && !$force) {
+       // If this is the default list, don't create a Session jet
+       user_cookie_save(array('islandora_bookmark_default' => $list_id));
+       return $newlist;
+    }
+    else {
+       $_SESSION['islandora_bookmark'][$list_id] = $newlist;
+       return static::getList($list_id);
+    }
   }
 
   /**
@@ -97,6 +104,9 @@ class BookmarkSession extends Bookmark {
    */
   public function delete() {
     unset($_SESSION['islandora_bookmark'][$this->bookmarkId]);
+    if (count($_SESSION['islandora_bookmark']) == 0) {
+       unset($_SESSION['islandora_bookmark']);
+    }
   }
 
   /**

--- a/includes/bookmark_session.inc
+++ b/includes/bookmark_session.inc
@@ -6,8 +6,10 @@
  */
 
 /**
- * Class that defines a Bookmark object. A Bookmark object needs only to be
- * constructed such that it contains a listname and listid for uniqueness.
+ * Class that defines a Bookmark object.
+ *
+ * A Bookmark object needs only to be constructed such that it
+ * contains a listname and listid for uniqueness.
  */
 class BookmarkSession extends Bookmark {
   /**
@@ -75,8 +77,8 @@ class BookmarkSession extends Bookmark {
    *   grab the global "$user" variable.
    * @param string $desc
    *   An optional description of the bookmark list.
-   * @param boolean $force
-   *   Force a list to be stored on session
+   * @param bool $force
+   *   Force a list to be stored on session.
    *
    * @return BookmarkDatabase
    *   A new Bookmark object.
@@ -89,13 +91,13 @@ class BookmarkSession extends Bookmark {
     $list_id = static::getKey($name);
     $newlist = new static($name, $desc);
     if (!$newlist->getIsDeletable() && !$force) {
-       // If this is the default list, don't create a Session jet
-       user_cookie_save(array('islandora_bookmark_default' => $list_id));
-       return $newlist;
+      // If this is the default list, don't create a Session jet.
+      user_cookie_save(array('islandora_bookmark_default' => $list_id));
+      return $newlist;
     }
     else {
-       $_SESSION['islandora_bookmark'][$list_id] = $newlist;
-       return static::getList($list_id);
+      $_SESSION['islandora_bookmark'][$list_id] = $newlist;
+      return static::getList($list_id);
     }
   }
 
@@ -105,7 +107,7 @@ class BookmarkSession extends Bookmark {
   public function delete() {
     unset($_SESSION['islandora_bookmark'][$this->bookmarkId]);
     if (count($_SESSION['islandora_bookmark']) == 0) {
-       unset($_SESSION['islandora_bookmark']);
+      unset($_SESSION['islandora_bookmark']);
     }
   }
 
@@ -145,4 +147,5 @@ class BookmarkSession extends Bookmark {
   public function addPid($pid) {
     $this->pidList[] = $pid;
   }
+
 }

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -765,7 +765,7 @@ function islandora_bookmark_fedora_repository_object_form(array $form, array &$f
     // @see https://www.drupal.org/docs/7/api/localization-api/dynamic-or-static-links-and-html-in-translatable-strings.
     $form['islandora_bookmark']['lists'] = array(
       '#type' => 'item',
-      '#prefix' => t('<h3>Bookmarked in:</h3'),
+      '#prefix' => t('<h3>Bookmarked in:</h3>'),
       '#items' => $links,
       '#theme' => 'item_list',
     );

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -121,6 +121,13 @@ function islandora_bookmark_access($list_id) {
   global $user;
 
   $bookmark_object = Bookmark::getList($list_id);
+  
+  // Special case, anonymous user trying to access it's non existing/fake default list
+  if (($bookmark_object === NULL) && (user_is_anonymous()) && isset($_COOKIE['Drupal_visitor_islandora_bookmark_default'])){
+     if (($list_id === $_COOKIE['Drupal_visitor_islandora_bookmark_default']) && (!isset($_SESSION) || !isset($_SESSION['islandora_bookmark']) || empty($_SESSION['islandora_bookmark']))) {
+        $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), $user, 'Default bookmark', TRUE);
+    }
+  }
   // We explicitly check anonymous (uid 0) as bookmarks shared with that user
   // are determined to be accessible to everyone.
   return $bookmark_object && ($bookmark_object->bookmarkOwner === $user->uid || in_array($user->uid, $bookmark_object->getUsers()) || in_array('0', $bookmark_object->getUsers()));
@@ -662,7 +669,7 @@ function islandora_bookmark_detailed_form_manage(array $form, array &$form_state
   $bookmark = Bookmark::getList($list_id);
 
   // Manage.
-  if ($bookmark->bookmarkOwner === $user->uid) {
+  if ($bookmark->bookmarkOwner === $user->uid && $bookmark->getIsDeletable()) {
     // Management.
     $form['bookmarks']['management'] = array(
       '#type' => 'fieldset',
@@ -760,7 +767,8 @@ function islandora_bookmark_fedora_repository_object_form(array $form, array &$f
     $form['islandora_bookmark']['lists'] = array(
       '#type' => 'item',
       '#prefix' => '<h3>' . t('Bookmarked in') . ':</h3>',
-      '#markup' => theme('item_list', array('items' => $links)),
+      '#items' => $links,
+      '#theme' => 'item_list',
     );
   }
 
@@ -1106,7 +1114,12 @@ function islandora_bookmark_add_pid(array $form, array &$form_state) {
     $object = islandora_object_load($pid);
 
     $bookmark_object = islandora_bookmark_get_bookmark_by_number($key);
-
+    //Now deal with the special use case of anonymouse
+    if (($bookmark_object === FALSE) && (user_is_anonymous())) {
+      // We are adding a PID to a list that is not in $_SESSION
+       $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), NULL, 'Default bookmark');
+    } 
+    
     try {
       $bookmark_object->addPids(array($pid));
       drupal_set_message(t('The object @label has been bookmarked in @listname.',

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Module used to track and manage user defined lists of pids.
@@ -105,14 +106,13 @@ function islandora_bookmark_menu() {
   return $items;
 }
 
-
 /**
  * Used to determine whether a current user can access the menu path.
  *
- * @global object $user
- *
  * @param int $list_id
  *   The ID of the list to access.
+ *
+ * @global object $user
  *
  * @return bool
  *   TRUE if the current user can access the given list, FALSE otherwise.
@@ -121,11 +121,12 @@ function islandora_bookmark_access($list_id) {
   global $user;
 
   $bookmark_object = Bookmark::getList($list_id);
-  
-  // Special case, anonymous user trying to access it's non existing/fake default list
-  if (($bookmark_object === NULL) && (user_is_anonymous()) && isset($_COOKIE['Drupal_visitor_islandora_bookmark_default'])){
-     if (($list_id === $_COOKIE['Drupal_visitor_islandora_bookmark_default']) && (!isset($_SESSION) || !isset($_SESSION['islandora_bookmark']) || empty($_SESSION['islandora_bookmark']))) {
-        $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), $user, 'Default bookmark', TRUE);
+
+  // Special case, anonymous user trying to access it's
+  // non existing/fake default list.
+  if (($bookmark_object === NULL) && (user_is_anonymous()) && isset($_COOKIE['Drupal_visitor_islandora_bookmark_default'])) {
+    if (($list_id === $_COOKIE['Drupal_visitor_islandora_bookmark_default']) && (!isset($_SESSION) || !isset($_SESSION['islandora_bookmark']) || empty($_SESSION['islandora_bookmark']))) {
+      $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), $user, 'Default bookmark', TRUE);
     }
   }
   // We explicitly check anonymous (uid 0) as bookmarks shared with that user
@@ -136,10 +137,10 @@ function islandora_bookmark_access($list_id) {
 /**
  * Used to determine whether a current user can access the menu path.
  *
- * @global object $user
- *
  * @param int $list_id
  *   The ID of the list to potentially delete.
+ *
+ * @global object $user
  *
  * @return bool
  *   TRUE if the current user can delete the given list, FALSE otherwise.
@@ -195,7 +196,7 @@ function islandora_bookmark_block_view($delta = '') {
   switch ($delta) {
     case 'islandora_bookmark':
       // Make sure we're on the islandora/object route.
-      if (arg(0) == 'islandora' AND arg(1) == 'object') {
+      if (arg(0) == 'islandora' and arg(1) == 'object') {
         // Don't do anything if we're beyond islandora/object/PID.
         // That is, only show the bookmark block if we're on the standard view.
         if (arg(3)) {
@@ -379,7 +380,8 @@ function islandora_bookmark_delete_bookmark_confirm(array $form, array &$form_st
   $form_state['bookmark_object'] = $bookmark_object;
   return confirm_form($form, t('Are you sure you want to delete the @type list %bookmark_name?', array(
     '%bookmark_name' => $bookmark_object->bookmarkName,
-    '@type' => variable_get('islandora_bookmark_type', 'bookmark'))), 'islandora-bookmark/listid/' . $list_id, t('This action cannot be undone.'), t('Delete'), t('Cancel'));
+    '@type' => variable_get('islandora_bookmark_type', 'bookmark'),
+  )), 'islandora-bookmark/listid/' . $list_id, t('This action cannot be undone.'), t('Delete'), t('Cancel'));
 }
 
 /**
@@ -389,9 +391,6 @@ function islandora_bookmark_delete_bookmark_confirm(array $form, array &$form_st
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
- *
- * @return array
- *   The Drupal form definition.
  */
 function islandora_bookmark_delete_bookmark_confirm_submit(array $form, array &$form_state) {
   module_load_include('inc', 'islandora_bookmark', 'includes/api');
@@ -434,7 +433,8 @@ function islandora_bookmark_remove_self_confirm(array $form, array &$form_state,
   $form_state['bookmark_object'] = $bookmark_object;
   return confirm_form($form, t('Are you sure you want to remove yourself from the @type %bookmark_name ?', array(
     '%bookmark_name' => $bookmark_object->bookmarkName,
-    '@type' => variable_get('islandora_bookmark_type', 'bookmark'))), 'islandora-bookmark/listid/' . $list_id, t('This action cannot be undone.'),
+    '@type' => variable_get('islandora_bookmark_type', 'bookmark'),
+  )), 'islandora-bookmark/listid/' . $list_id, t('This action cannot be undone.'),
     t('Delete'),
     t('Cancel'));
 }
@@ -442,12 +442,12 @@ function islandora_bookmark_remove_self_confirm(array $form, array &$form_state,
 /**
  * Submit handler for removing self from a Bookmark.
  *
- * @global stdClass $user
- *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
+ *
+ * @global stdClass $user
  */
 function islandora_bookmark_remove_self_confirm_submit(array $form, array &$form_state) {
   module_load_include('inc', 'islandora_bookmark', 'includes/api');
@@ -500,7 +500,7 @@ function islandora_bookmark_update_bookmark(array $form, array &$form_state) {
  * @return string
  *   The markup for the Fedora object in the table.
  */
-function islandora_bookmark_generate_markup($pid, $object_url_info = NULL) {
+function islandora_bookmark_generate_markup($pid, array $object_url_info = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $fedora_object = islandora_object_load($pid);
 
@@ -542,7 +542,6 @@ function islandora_bookmark_generate_markup($pid, $object_url_info = NULL) {
   return $output;
 }
 
-
 /**
  * Themes a Fedora object.
  *
@@ -556,7 +555,7 @@ function islandora_bookmark_generate_markup($pid, $object_url_info = NULL) {
  *   an associative array containing the output from theme
  *   islandora-bookmark_object_display
  */
-function islandora_bookmark_object_display($object_url_info) {
+function islandora_bookmark_object_display(array $object_url_info) {
   $output = theme('islandora_bookmark_object_display', array('object_url_info' => $object_url_info));
 
   return array('Default output' => $output);
@@ -598,14 +597,14 @@ function islandora_bookmark_display_list($list_id) {
  *
  * Shows bookmarks, remove buttons, export and share functionality.
  *
- * @global object $user
- *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
  * @param mixed $list_id
  *   The identifier for the current list.
+ *
+ * @global object $user
  *
  * @return array
  *   The Drupal form definition.
@@ -717,7 +716,7 @@ function islandora_bookmark_detailed_form_manage(array $form, array &$form_state
  * @param string $pid
  *   PID to pass to the form. PID is gathered from url.
  *
- * @return string|NULL
+ * @return string|null
  *   The markup of the object form or NULL otherwise.
  */
 function islandora_bookmark_get_object_form($pid = NULL) {
@@ -763,10 +762,10 @@ function islandora_bookmark_fedora_repository_object_form(array $form, array &$f
       $bookmark_object = islandora_bookmark_get_bookmark_by_number($value);
       $links[] = l($bookmark_object->bookmarkName, 'islandora-bookmark/listid/' . $bookmark_object->getId());
     }
-
+    // @see https://www.drupal.org/docs/7/api/localization-api/dynamic-or-static-links-and-html-in-translatable-strings.
     $form['islandora_bookmark']['lists'] = array(
       '#type' => 'item',
-      '#prefix' => '<h3>' . t('Bookmarked in') . ':</h3>',
+      '#prefix' => t('<h3>Bookmarked in:</h3'),
       '#items' => $links,
       '#theme' => 'item_list',
     );
@@ -788,7 +787,9 @@ function islandora_bookmark_fedora_repository_object_form(array $form, array &$f
       if (user_access('use islandora_bookmark')) {
         if (!count($containing_lists)) {
           $form['islandora_bookmark']['title'] = array(
-            '#markup' => '<h3>' . t('@type', array('@type' => ucwords(variable_get('islandora_bookmark_type', 'bookmark')))) . 's:</h3>',
+            '#prefix' => '<h3>',
+            '#markup' => t('@type', array('@type' => ucwords(variable_get('islandora_bookmark_type', 'bookmark')))),
+            '#suffix' => 's:</h3>',
           );
         }
         $form['islandora_bookmark']['add_bookmarks'] = array(
@@ -889,12 +890,12 @@ function islandora_bookmark_export_pids_as_csv($pids) {
 /**
  * Form constructor for the Bookmark overview form.
  *
- * @global stdClass $user
- *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
+ *
+ * @global stdClass $user
  *
  * @return array
  *   The Drupal form definition.
@@ -1024,12 +1025,12 @@ function islandora_bookmark_form_overview_table(array $bookmark_objs) {
 /**
  * Form constructor for the add Bookmark form.
  *
- * @global stdClass $user
- *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
+ *
+ * @global stdClass $user
  *
  * @return array
  *   The Drupal form definition.
@@ -1066,12 +1067,12 @@ function islandora_bookmark_add_form(array $form, array &$form_state) {
 /**
  * Form submission handler for the islandora_bookmark_add_form().
  *
- * @global stdClass $user
- *
  * @param array $form
  *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
+ *
+ * @global stdClass $user
  */
 function islandora_bookmark_add_form_submit(array $form, array &$form_state) {
   global $user;
@@ -1114,12 +1115,12 @@ function islandora_bookmark_add_pid(array $form, array &$form_state) {
     $object = islandora_object_load($pid);
 
     $bookmark_object = islandora_bookmark_get_bookmark_by_number($key);
-    //Now deal with the special use case of anonymouse
+    // Now deal with the special use case of anonymouse.
     if (($bookmark_object === FALSE) && (user_is_anonymous())) {
-      // We are adding a PID to a list that is not in $_SESSION
-       $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), NULL, 'Default bookmark');
-    } 
-    
+      // We are adding a PID to a list that is not in $_SESSION.
+      $bookmark_object = BookmarkDefaultSessionList::createNewList(t('My Default List'), NULL, 'Default bookmark');
+    }
+
     try {
       $bookmark_object->addPids(array($pid));
       drupal_set_message(t('The object @label has been bookmarked in @listname.',

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -765,7 +765,7 @@ function islandora_bookmark_fedora_repository_object_form(array $form, array &$f
     // @see https://www.drupal.org/docs/7/api/localization-api/dynamic-or-static-links-and-html-in-translatable-strings.
     $form['islandora_bookmark']['lists'] = array(
       '#type' => 'item',
-      '#prefix' => t('<h3>Bookmarked in:</h3>'),
+      '#prefix' => t("!h1Bookmarked in:!h2", array("!h1" => "<h3>", "!h2" => ":</h3>")),
       '#items' => $links,
       '#theme' => 'item_list',
     );


### PR DESCRIPTION
ISLANDORA-1651: https://jira.duraspace.org/browse/ISLANDORA-1651

# What does this Pull Request do?

Islandora bookmark allows anonymous users to manage Bookmarks by displaying a Block to add PIDS and keeping Bookmark info available using the global $_SESSION PHP variable. When that happens,  Drupal initialises a full blown SESSION using SESSxxxx cookie, 
(see https://api.drupal.org/api/drupal/includes!bootstrap.inc/function/drupal_settings_initialize/7)
same used by Drupal to track current logged in users. 

This prevents caching systems like Varnish or Memcached to detect correctly if a page is being viewed by an anonymous user (and candidate for caching) or by a logged User (different caching strategy, if any).

A Drupal session in place for anonymous users adds performance penalties. Read 
http://facingworlds.com/drupal-7-bootstrap-explained-drupalbootstrapsession-and-drupals-session-handling.

 This PULL request avoids initializing the SESSION in question at all when not needed and only makes use of it when an Anonymous user actually saves something to a Bookmark session, instead of when just exposed to the functionality as before. This fix has been in production at DCMNY.org for over a year already. 

Relevant to cookie creation:
https://github.com/Islandora/islandora_bookmark/pull/101/files#diff-3196d324ec7e08230f97233bfabca6ffR95

# What's new?
Islandora Bookmark Drupal Block for Anonymous users can be used without caching penalties.

# How should this be tested?

If running under Varnish/Memcached and without this fix, verify  Session cookies when the Bookmark Block provided by this module is enabled for anonymous users. You should see SESSxxxx even if not using bookmarks at all, just by accessing an object's page that displays the block. Look at your caching headers. You will see that Varnish simply skips caching once the Block is displayed (even once) for all the lifespan of that cookie, on any page of an islandora Site. 

Enable this module and reset your browser ( the previous cookie will survive even an Atomic bomb). make sure the cookie is gone. All existing functionality should still work, but if anonymous does not add an Object to PID then SESSxxxx should not be around.

If you want to be even finer, you can test page loading times with and without patch when displaying the Bookmark Block. With the Fix it should be faster, the amount will vary of course.

# Additional Notes:
This Pull request includes a lot of Drupal Coding Standards fixes because:
- drupal/coder                           8.2.12 
- squizlabs/php_codesniffer              2.9.1 



* Does this change require documentation to be updated? 
No
* Does this change add any new dependencies? 
No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
No
* Could this change impact execution of existing code?
No

# Interested parties
 @Islandora/7-x-1-x-committers @jonathangreen @adam-vessey @jordandukart 