### PR TITLE
Address ISLANDORA-2487; resolve errors when bulk adding bookmarks

### DIFF
--- a/includes/solr_results.inc
+++ b/includes/solr_results.inc
@@ -496,7 +496,7 @@ class IslandoraSolrResultsBookmark extends IslandoraSolrResults {
     $clicked_button = $form_state['clicked_button'];
     if (isset($clicked_button['#action_validate'])) {
       foreach ((array) $clicked_button['#action_validate'] as $validator) {
-        call_user_func(array($this, $validator), $form, $form_state);
+        call_user_func_array(array($this, $validator), array($form, &$form_state));
       }
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2487

# What does this Pull Request do?
Resolves form validation errors when bulking adding bookmarks from Solr results.

# What's new?
Call call_user_func_array instead of call_user_func

# How should this be tested?
Enable bookmark display for Solr displays
Search Solr and add some results to a bookmark list
Prior to this PR, you will be greeted with:

Warning: Parameter 2 to IslandoraSolrResultsBookmark::hasListSelected() expected to be a reference, value given in IslandoraSolrResultsBookmark->formValidate() (line 499 of /var/www/drupal7/sites/all/modules/islandora_bookmark/includes/solr_results.inc).

Warning: Parameter 2 to IslandoraSolrResultsBookmark::hasObjectsSelected() expected to be a reference, value given in IslandoraSolrResultsBookmark->formValidate() (line 499 of /var/www/drupal7/sites/all/modules/islandora_bookmark/includes/solr_results.inc).

After applying this PR there's no errors.


# Additional Notes:

# Interested parties
Tagging @jordandukart as maintainer and @Islandora/7-x-1-x-committers 
