### PR TITLE
ISLANDORA-2486: PHP 7.2 - Fixing bug when passing NULL to count function

### DIFF
--- a/includes/bookmark.inc
+++ b/includes/bookmark.inc
@@ -944,7 +944,7 @@ abstract class Bookmark implements BookmarkInterface {
     }
 
     $errors = form_get_errors();
-    if (count($errors) === 0) {
+    if (!$errors) {
       $page = pager_default_initialize(
           $this->getPidCount(), variable_get('islandora_bookmark_detailed_page_elements', 10), $form_state['islandora_bookmark_pager_element']
       );

--- a/islandora_bookmark.module
+++ b/islandora_bookmark.module
@@ -1099,7 +1099,7 @@ function islandora_bookmark_add_form_submit(array $form, array &$form_state) {
 function islandora_bookmark_add_pid(array $form, array &$form_state) {
   $errors = form_get_errors();
 
-  if (count($errors) === 0) {
+  if (!$errors) {
     module_load_include('inc', 'islandora_bookmark', 'includes/api');
     $key = $form_state['values']['add_bookmarks'];
     $pid = $form_state['islandora_bookmark_pid'];


### PR DESCRIPTION
**ISLANDORA-2486**: https://jira.duraspace.org/browse/ISLANDORA-2486

# What does this Pull Request do?
As of PHP 7.2 (https://www.php.net/manual/en/migration72.incompatible.php) the 'count' function throws a warning when receiving a NULL value. This Pull Request removes two instances of using count during error reporting on form submission that were causing errors to appear both during adding and removing bookmarks from a bookmark list.

# What's new?
Checking directly against the $error variable rather than checking the count.

# How should this be tested?
1. Create a bookmark list
2. Add an item to that list
3. Remove that item from the bookmark list

Before applying the change note the errors that occur at steps 2 and 3. After applying the PR the errors should no longer occur.

Adding Bookmark Warning:
![Screen Shot 2019-10-16 at 11 53 30 AM](https://user-images.githubusercontent.com/53783039/66931229-2e62a000-f00c-11e9-9970-7215cf9c24f7.png)

Removing Bookmark(s) Warning:
![Screen Shot 2019-10-16 at 11 53 47 AM](https://user-images.githubusercontent.com/53783039/66931280-41757000-f00c-11e9-9582-1b33d93733c7.png)

# Interested parties
@Islandora/7-x-1-x-committers
